### PR TITLE
add line-height to heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@
                         <div class="row">
                             <div class="col-md-offset-1 col-sm-10 col-sm-offset-1 text-center col-md-10">
                                 <img alt="logo" class="logo" src="img/fossasia-squarewhite-path.png">
-                                <span class="uppercase text-white sub-heading-font ">OpenTechSummit Singapore</span> <h1 class="large-h1 text-white">
+                                <span class="uppercase text-white sub-heading-font " style="line-height: 1.0em;">OpenTechSummit Singapore</span> <h1 class="large-h1 text-white">
                                  <!--   <span>The future is FOSS!</span><br> -->
                                        <span>Asia's Premier Developer Event<br>
                                    March 19 - 22, 2020<br>
@@ -2349,7 +2349,7 @@
                         <h1>OpenTech Hackathon with UNESCO<br>
                         Sat March 21 - Sun March 22</h1>
                         <p class="lead">
-                            Developers, designers, tech contributors, bloggers, and journalists celebrate 10 years FOSSASIA in the OpenTech Hackathon! Awesome prizes are waiting for you! Tickets are free. Number of registrants is limited.
+                            Developers, designers, tech contributors, bloggers, and journalists celebrate 10 years FOSSASIA in the OpenTech Hackathon! Awesome prizes are waiting for you! Tickets are free. Number of registrants are limited.
                         </p>
                         <a href="https://fossasia-hackathon.devpost.com/" class="btn" target="_self">
                             </i>Sign up Here</a>


### PR DESCRIPTION
There is responsive issue for mobiles having screen width less  than 576 approx (tested on 425 and 325), just added line-height:1.0em; so that in mobile having above mentioned screen widths, heading "OPENTECHSUMMIT SINGAPORE" will not get merge together.

Checkout the following links for better understanding.
[Before - OPENTECHSUMMIT SINGAPORE ](https://www.dropbox.com/s/r9k8yhtyew91h0p/before-fossasia.png?dl=0)

[After - OPENTECHSUMMIT SINGAPORE ](https://www.dropbox.com/s/8i43nh875x2k7rr/after-fossasia.png?dl=0)